### PR TITLE
Security hardening: input validation, file permissions, and --redact flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ credentials.json
 secrets.yaml
 .env.local
 .env.*.local
+
+# Claude Code project memory (internal use only)
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ secrets.yaml
 
 # Claude Code project memory (internal use only)
 CLAUDE.md
+
+# Virtual environment
+.venv/

--- a/src/aws_inventory/cli.py
+++ b/src/aws_inventory/cli.py
@@ -49,6 +49,7 @@ def print_progress(service: str, status: str) -> None:
 @click.option('--include-global', is_flag=True, help='Include global services even when filtering by non-global regions')
 @click.option('--exclude-defaults', is_flag=True, help='Exclude default AWS resources (default VPCs, security groups, etc.)')
 @click.option('--no-db', is_flag=True, help='Skip local database storage')
+@click.option('--redact', is_flag=True, help='Redact AWS account IDs in output files (replace with [REDACTED])')
 @click.pass_context
 def main(
     ctx,
@@ -64,7 +65,8 @@ def main(
     timings: bool,
     include_global: bool,
     exclude_defaults: bool,
-    no_db: bool
+    no_db: bool,
+    redact: bool
 ) -> None:
     """
     awsmap - Map and inventory AWS resources.
@@ -248,7 +250,7 @@ def main(
 
     # Format output
     try:
-        output_content = format_output(result, output_format)
+        output_content = format_output(result, output_format, redact=redact)
     except Exception as e:
         click.echo(f"Error formatting output: {e}", err=True)
         sys.exit(1)
@@ -257,7 +259,8 @@ def main(
     if not output_file:
         timestamp = time.strftime('%Y%m%d_%H%M%S')
         ext = output_format
-        output_file = f"{account_id}_inventory_{timestamp}.{ext}"
+        file_account_id = "REDACTED" if redact else account_id
+        output_file = f"{file_account_id}_inventory_{timestamp}.{ext}"
 
     # Write output
     try:

--- a/src/aws_inventory/completions.py
+++ b/src/aws_inventory/completions.py
@@ -49,6 +49,9 @@ def complete_regions(ctx, param, incomplete):
     ]
 
 
+_AWS_CONFIG_MAX_BYTES = 1 * 1024 * 1024  # 1 MB limit for AWS config files
+
+
 def complete_profiles(ctx, param, incomplete):
     """Complete AWS profile names from ~/.aws/credentials and ~/.aws/config."""
     try:
@@ -56,6 +59,12 @@ def complete_profiles(ctx, param, incomplete):
         for path in ["~/.aws/credentials", "~/.aws/config"]:
             full = os.path.expanduser(path)
             if os.path.exists(full):
+                # Guard against abnormally large or malformed config files
+                try:
+                    if os.path.getsize(full) > _AWS_CONFIG_MAX_BYTES:
+                        continue
+                except OSError:
+                    continue
                 cp = configparser.ConfigParser()
                 cp.read(full)
                 for section in cp.sections():

--- a/src/aws_inventory/config.py
+++ b/src/aws_inventory/config.py
@@ -3,6 +3,7 @@ User configuration for awsmap (~/.awsmap/config).
 """
 
 import os
+import pathlib
 
 
 CONFIG_PATH = os.path.expanduser("~/.awsmap/config")
@@ -43,6 +44,17 @@ def validate_config(key, value):
         return f"Unknown key '{key}'. Valid keys: {valid}"
     allowed = _VALID_KEYS[key]
     if allowed is None:
+        # Special validation for 'db': reject path traversal attempts
+        if key == "db":
+            expanded = os.path.expanduser(value)
+            try:
+                resolved = str(pathlib.Path(expanded).resolve())
+                home = str(pathlib.Path.home())
+                # Must stay within the user's home directory
+                if not resolved.startswith(home + os.sep) and resolved != home:
+                    return f"'db' path must be within your home directory, got '{value}'"
+            except (ValueError, OSError):
+                return f"'db' path is invalid: '{value}'"
         return None
     if allowed == "integer":
         if not value.isdigit() or int(value) < 1:

--- a/src/aws_inventory/db.py
+++ b/src/aws_inventory/db.py
@@ -51,8 +51,19 @@ def get_connection(db_path=None):
     """Open (or create) the SQLite database and ensure schema exists."""
     if db_path is None:
         db_path = DEFAULT_DB_PATH
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    db_dir = os.path.dirname(db_path)
+    os.makedirs(db_dir, exist_ok=True)
+    # Restrict directory so only the owner can read/write/execute
+    try:
+        os.chmod(db_dir, 0o700)
+    except OSError:
+        pass
     conn = sqlite3.connect(db_path, timeout=30)
+    # Restrict DB file so only the owner can read/write
+    try:
+        os.chmod(db_path, 0o600)
+    except OSError:
+        pass
     conn.execute("PRAGMA journal_mode=WAL")
     conn.executescript(SCHEMA_SQL)
     _migrate(conn)

--- a/src/aws_inventory/formatter.py
+++ b/src/aws_inventory/formatter.py
@@ -1230,13 +1230,29 @@ def format_html(data: Dict[str, Any]) -> str:
     return html
 
 
-def format_output(data: Dict[str, Any], format_type: str) -> str:
+def redact_account_ids(content: str, account_id: str) -> str:
+    """Replace occurrences of account_id with [REDACTED] in output content.
+
+    Args:
+        content: Formatted output string (HTML, JSON, CSV, etc.)
+        account_id: AWS account ID to redact (12-digit string)
+
+    Returns:
+        Content with account_id replaced by [REDACTED]
+    """
+    if not account_id or not account_id.strip():
+        return content
+    return content.replace(account_id, "[REDACTED]")
+
+
+def format_output(data: Dict[str, Any], format_type: str, redact: bool = False) -> str:
     """
     Format inventory data in the specified format.
 
     Args:
         data: Inventory data with metadata and resources
         format_type: Output format (json, csv, html)
+        redact: If True, replace AWS account IDs with [REDACTED] in output
 
     Returns:
         Formatted string
@@ -1247,13 +1263,19 @@ def format_output(data: Dict[str, Any], format_type: str) -> str:
     format_type = format_type.lower()
 
     if format_type == 'json':
-        return format_json(data)
+        content = format_json(data)
     elif format_type == 'csv':
-        return format_csv(data)
+        content = format_csv(data)
     elif format_type == 'html':
-        return format_html(data)
+        content = format_html(data)
     else:
         raise ValueError(f"Unsupported format: {format_type}")
+
+    if redact:
+        account_id = data.get('metadata', {}).get('account_id', '')
+        content = redact_account_ids(content, account_id)
+
+    return content
 
 
 def export_file(content: str, file_path: str) -> None:
@@ -1264,5 +1286,11 @@ def export_file(content: str, file_path: str) -> None:
         content: Content to write
         file_path: Destination file path
     """
+    import os
     with open(file_path, 'w', encoding='utf-8') as f:
         f.write(content)
+    # Restrict output file so only the owner can read/write (no group/world access)
+    try:
+        os.chmod(file_path, 0o600)
+    except OSError:
+        pass

--- a/src/aws_inventory/nlq.py
+++ b/src/aws_inventory/nlq.py
@@ -2967,7 +2967,9 @@ def _fix_partial_value_match(sql, conn, *, enable_fuzzy_fallback=True):
         # Skip tag exact matches (Environment=production should not become LIKE)
         if "tags" in field_expr:
             continue
-        like_clause = f"{field_expr} LIKE '%{value}%'"
+        # Sanitize value: escape SQLite LIKE special chars and single quotes
+        safe_value = value.replace("'", "''").replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        like_clause = f"{field_expr} LIKE '%{safe_value}%' ESCAPE '\\'"
         new_sql = new_sql[:m.start()] + like_clause + new_sql[m.end():]
 
     if new_sql != sql:

--- a/src/aws_inventory/queries_lib.py
+++ b/src/aws_inventory/queries_lib.py
@@ -6,6 +6,11 @@ import re
 from aws_inventory.nlq import _scan_where
 
 
+def _escape_sql_string(value: str) -> str:
+    """Escape a string value for safe inline SQL interpolation (single-quote escaping)."""
+    return value.replace("'", "''")
+
+
 # Directories searched for .sql files (built-in first, then user)
 _BUILTIN_DIR = os.path.join(os.path.dirname(__file__), "queries")
 _USER_DIR = os.path.join(os.path.expanduser("~"), ".awsmap", "queries")
@@ -102,7 +107,16 @@ def prepare_query(raw_sql, meta, account_id=None, params=None):
 
     # Inject optional filters for common params (account already handled via scan_filter)
     if "service" in params:
-        svc = params.pop("service").replace("'", "''")
+        svc_raw = params.pop("service")
+        # Validate service against known collectors to prevent injection
+        try:
+            from aws_inventory.collector import get_available_services
+            _known_services = set(get_available_services())
+        except Exception:
+            _known_services = None
+        if _known_services is not None and svc_raw not in _known_services:
+            raise ValueError(f"Unknown service: {svc_raw!r}")
+        svc = _escape_sql_string(svc_raw)
         # Inject service filter before GROUP BY/ORDER BY/LIMIT or at end
         inject_m = re.search(r'\s+(?:GROUP|ORDER|LIMIT)\b', raw_sql, re.IGNORECASE)
         clause = f" AND service = '{svc}'"
@@ -112,7 +126,11 @@ def prepare_query(raw_sql, meta, account_id=None, params=None):
             raw_sql += clause
 
     if "region" in params:
-        rgn = params.pop("region").replace("'", "''")
+        rgn_raw = params.pop("region")
+        # Validate region: alphanumeric + hyphens only
+        if not re.fullmatch(r'[a-z0-9-]{1,30}', rgn_raw):
+            raise ValueError(f"Invalid region: {rgn_raw!r}")
+        rgn = _escape_sql_string(rgn_raw)
         inject_m = re.search(r'\s+(?:GROUP|ORDER|LIMIT)\b', raw_sql, re.IGNORECASE)
         clause = f" AND region = '{rgn}'"
         if inject_m:
@@ -120,8 +138,8 @@ def prepare_query(raw_sql, meta, account_id=None, params=None):
         else:
             raw_sql += clause
 
-    # Replace remaining {param} placeholders
+    # Replace remaining {param} placeholders (escape single quotes)
     for key, value in params.items():
-        raw_sql = raw_sql.replace("{" + key + "}", value.replace("'", "''"))
+        raw_sql = raw_sql.replace("{" + key + "}", _escape_sql_string(value))
 
     return raw_sql

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -1,0 +1,87 @@
+"""
+Tests for security hardening in config.py.
+
+Verifies path traversal prevention for the 'db' config key
+and that the file size limit in completions.py is enforced.
+"""
+
+import os
+import tempfile
+import pytest
+
+from aws_inventory.config import validate_config
+
+
+# ── path traversal prevention ─────────────────────────────────────────────────
+
+def test_db_path_traversal_rejected():
+    """Path containing ../ that resolves outside home must be rejected."""
+    error = validate_config("db", "/tmp/evil.db")
+    assert error is not None, "Expected error for path outside home"
+    assert "home directory" in error
+
+
+def test_db_path_traversal_dotdot_rejected():
+    """Relative path with ../ must be rejected."""
+    error = validate_config("db", "~/../../../etc/passwd")
+    assert error is not None, "Expected error for ../ traversal"
+
+
+def test_db_path_within_home_accepted():
+    """Path within home directory must be accepted."""
+    home = os.path.expanduser("~")
+    valid_path = os.path.join(home, ".awsmap", "custom.db")
+    error = validate_config("db", valid_path)
+    assert error is None, f"Expected no error for valid path, got: {error}"
+
+
+def test_db_default_path_accepted():
+    """Default ~/.awsmap/inventory.db path must be accepted."""
+    error = validate_config("db", "~/.awsmap/inventory.db")
+    assert error is None, f"Expected no error for default path, got: {error}"
+
+
+def test_db_absolute_outside_home_rejected():
+    """Absolute path outside home directory must be rejected."""
+    error = validate_config("db", "/var/db/inventory.db")
+    assert error is not None, "Expected error for absolute path outside home"
+
+
+def test_db_etc_passwd_rejected():
+    """Classic /etc/passwd path must be rejected."""
+    error = validate_config("db", "/etc/passwd")
+    assert error is not None, "Expected error for /etc/passwd"
+
+
+# ── other config key validation ───────────────────────────────────────────────
+
+def test_unknown_key_rejected():
+    """Unknown config keys must be rejected."""
+    error = validate_config("unknown_key", "value")
+    assert error is not None
+
+
+def test_valid_format_accepted():
+    """Valid format values must be accepted."""
+    for fmt in ("html", "json", "csv"):
+        error = validate_config("format", fmt)
+        assert error is None, f"Expected no error for format={fmt}"
+
+
+def test_invalid_format_rejected():
+    """Invalid format values must be rejected."""
+    error = validate_config("format", "xml")
+    assert error is not None
+
+
+def test_valid_workers_accepted():
+    """Positive integer workers value must be accepted."""
+    error = validate_config("workers", "10")
+    assert error is None
+
+
+def test_invalid_workers_rejected():
+    """Non-integer or zero workers must be rejected."""
+    assert validate_config("workers", "0") is not None
+    assert validate_config("workers", "-1") is not None
+    assert validate_config("workers", "abc") is not None

--- a/tests/test_file_permissions.py
+++ b/tests/test_file_permissions.py
@@ -1,0 +1,96 @@
+"""
+Tests for file permission hardening in db.py and formatter.py.
+
+Verifies that the SQLite database directory/file and all exported
+output files are created with owner-only (0o600/0o700) permissions.
+"""
+
+import os
+import stat
+import tempfile
+import pytest
+
+from aws_inventory.db import get_connection
+from aws_inventory.formatter import export_file
+
+
+# ── database permissions ──────────────────────────────────────────────────────
+
+def test_db_directory_permissions():
+    """~/.awsmap/ (or custom dir) must be created with 0o700."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "subdir", "inventory.db")
+        conn = get_connection(db_path)
+        conn.close()
+
+        dir_mode = stat.S_IMODE(os.stat(os.path.dirname(db_path)).st_mode)
+        assert dir_mode == 0o700, f"Expected 0o700, got {oct(dir_mode)}"
+
+
+def test_db_file_permissions():
+    """The SQLite database file must be created with 0o600."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "subdir", "inventory.db")
+        conn = get_connection(db_path)
+        conn.close()
+
+        file_mode = stat.S_IMODE(os.stat(db_path).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+def test_db_file_permissions_existing_db():
+    """Permissions must be enforced even when opening an existing database."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "subdir", "inventory.db")
+        # First open creates the DB
+        conn = get_connection(db_path)
+        conn.close()
+        # Second open re-applies permissions
+        conn = get_connection(db_path)
+        conn.close()
+
+        file_mode = stat.S_IMODE(os.stat(db_path).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600 on re-open, got {oct(file_mode)}"
+
+
+# ── output file permissions ───────────────────────────────────────────────────
+
+def test_export_file_permissions_html():
+    """Exported HTML files must be created with 0o600."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "report.html")
+        export_file("<html></html>", out)
+
+        file_mode = stat.S_IMODE(os.stat(out).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+def test_export_file_permissions_json():
+    """Exported JSON files must be created with 0o600."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "report.json")
+        export_file('{"resources": []}', out)
+
+        file_mode = stat.S_IMODE(os.stat(out).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+def test_export_file_permissions_csv():
+    """Exported CSV files must be created with 0o600."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "report.csv")
+        export_file("service,type,id\n", out)
+
+        file_mode = stat.S_IMODE(os.stat(out).st_mode)
+        assert file_mode == 0o600, f"Expected 0o600, got {oct(file_mode)}"
+
+
+def test_export_file_content_intact():
+    """Permissions fix must not corrupt file content."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = os.path.join(tmpdir, "report.json")
+        content = '{"test": "value"}'
+        export_file(content, out)
+
+        with open(out) as f:
+            assert f.read() == content

--- a/tests/test_nlq_injection.py
+++ b/tests/test_nlq_injection.py
@@ -1,0 +1,112 @@
+"""
+Tests for SQL injection hardening in nlq.py (_fix_partial_value_match).
+
+Verifies that user-derived values in LIKE clauses are properly escaped
+so that SQL special characters cannot break out of the string context.
+"""
+
+import sqlite3
+import pytest
+
+from aws_inventory.nlq import _fix_partial_value_match
+
+
+@pytest.fixture
+def conn():
+    """In-memory SQLite DB with a minimal resources table."""
+    c = sqlite3.connect(":memory:")
+    c.executescript("""
+        CREATE TABLE resources (
+            rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+            scan_id TEXT,
+            service TEXT,
+            type TEXT,
+            id TEXT,
+            arn TEXT,
+            name TEXT,
+            region TEXT,
+            account_id TEXT,
+            is_default INTEGER DEFAULT 0,
+            is_current INTEGER DEFAULT 1,
+            details TEXT,
+            tags TEXT
+        );
+        INSERT INTO resources (scan_id, service, type, id, name, region, account_id, is_current)
+        VALUES ('s1', 's3', 'bucket', 'my-bucket', 'my-bucket', 'us-east-1', '123456789012', 1);
+    """)
+    return c
+
+
+def test_normal_name_becomes_like(conn):
+    """A normal name= clause with no exact match is widened to LIKE '%value%'."""
+    # 'bucket' is a partial match for 'my-bucket' in the DB — exact match
+    # returns a row so no widening needed. Use a value that matches partially
+    # but not exactly to trigger the LIKE fallback.
+    sql = "SELECT * FROM resources WHERE is_current=1 AND name='bucket'"
+    result = _fix_partial_value_match(sql, conn)
+    # Either widened to LIKE (partial match found) or returned as-is (no rows)
+    # The important thing is the result is valid SQL
+    assert isinstance(result, str)
+    conn.execute(result)  # Must not raise
+
+
+def test_single_quote_escaped(conn):
+    """Single quotes in value must be escaped to '' to prevent injection."""
+    sql = "SELECT * FROM resources WHERE is_current=1 AND name='test''injection'"
+    # Should not raise; the escaped SQL must be valid
+    result = _fix_partial_value_match(sql, conn)
+    # Result is valid SQL (no unhandled exception)
+    assert isinstance(result, str)
+
+
+def test_percent_wildcard_escaped(conn):
+    """% in user value should be escaped so it doesn't act as a wildcard."""
+    sql = "SELECT * FROM resources WHERE is_current=1 AND name='100%done'"
+    result = _fix_partial_value_match(sql, conn)
+    if "LIKE" in result:
+        # The % in the value must be escaped with backslash
+        assert "\\%" in result or "100" in result
+
+
+def test_underscore_escaped(conn):
+    """_ in user value should be escaped so it doesn't act as a single-char wildcard."""
+    sql = "SELECT * FROM resources WHERE is_current=1 AND name='my_bucket'"
+    result = _fix_partial_value_match(sql, conn)
+    if "LIKE" in result:
+        assert "\\_" in result or "my_bucket" in result
+
+
+def test_or_injection_does_not_return_extra_rows(conn):
+    """Classic OR 1=1 injection attempt should not return unintended rows."""
+    # If injection worked, the LIKE clause would be: name LIKE '%x' OR '1'='1%'
+    # which would match all rows. Our escaping should prevent this.
+    sql = "SELECT * FROM resources WHERE is_current=1 AND service='s3' AND name='x'' OR ''1''=''1'"
+    # This should not raise and should not widen to a dangerous pattern
+    result = _fix_partial_value_match(sql, conn)
+    assert isinstance(result, str)
+    # The result SQL must be executable without error
+    conn.execute(result)
+
+
+def test_backslash_escaped(conn):
+    """Backslash in value must be escaped to prevent ESCAPE sequence manipulation."""
+    sql = r"SELECT * FROM resources WHERE is_current=1 AND name='test\value'"
+    result = _fix_partial_value_match(sql, conn)
+    assert isinstance(result, str)
+    # Must execute without error
+    conn.execute(result)
+
+
+def test_known_exact_values_skipped(conn):
+    """Values like 'global' should not be converted to LIKE clauses."""
+    sql = "SELECT * FROM resources WHERE is_current=1 AND name='global'"
+    result = _fix_partial_value_match(sql, conn)
+    # 'global' is in the skip list, should remain as exact match
+    assert "LIKE" not in result
+
+
+def test_service_field_not_widened(conn):
+    """service= clauses must never be widened to LIKE (allowlist field)."""
+    sql = "SELECT * FROM resources WHERE is_current=1 AND service='s3'"
+    result = _fix_partial_value_match(sql, conn)
+    assert "LIKE" not in result

--- a/tests/test_queries_lib_injection.py
+++ b/tests/test_queries_lib_injection.py
@@ -1,0 +1,92 @@
+"""
+Tests for SQL injection hardening in queries_lib.py (prepare_query).
+
+Verifies that service/region validation and parameter escaping
+prevent injection through named query parameters.
+"""
+
+import pytest
+
+from aws_inventory.queries_lib import prepare_query, _escape_sql_string
+
+
+# prepare_query signature: (raw_sql, meta, account_id=None, params=None)
+# meta must be a dict with at least {"params": []} key
+
+BASE_META = {"name": "test", "description": "", "params": []}
+BASE_SQL = "SELECT * FROM resources WHERE {scan_filter}"
+
+
+# ── _escape_sql_string ────────────────────────────────────────────────────────
+
+def test_escape_single_quote():
+    assert _escape_sql_string("O'Reilly") == "O''Reilly"
+
+
+def test_escape_multiple_quotes():
+    assert _escape_sql_string("it's a 'test'") == "it''s a ''test''"
+
+
+def test_escape_no_special_chars():
+    assert _escape_sql_string("normal") == "normal"
+
+
+def test_escape_empty_string():
+    assert _escape_sql_string("") == ""
+
+
+# ── service validation ────────────────────────────────────────────────────────
+
+def test_invalid_service_raises():
+    """Unknown service name should raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown service"):
+        prepare_query(BASE_SQL, BASE_META, params={"service": "not_a_real_service_xyz"})
+
+
+def test_valid_service_accepted():
+    """Known service name should be injected without error."""
+    result = prepare_query(BASE_SQL, BASE_META, params={"service": "s3"})
+    assert "service = 's3'" in result
+
+
+def test_service_injection_attempt_rejected():
+    """SQL injection via service param should be rejected by allowlist."""
+    with pytest.raises(ValueError, match="Unknown service"):
+        prepare_query(BASE_SQL, BASE_META, params={"service": "s3' OR '1'='1"})
+
+
+# ── region validation ─────────────────────────────────────────────────────────
+
+def test_valid_region_accepted():
+    """Valid region should be injected without error."""
+    result = prepare_query(BASE_SQL, BASE_META, params={"region": "us-east-1"})
+    assert "region = 'us-east-1'" in result
+
+
+def test_invalid_region_raises():
+    """Region with SQL characters should be rejected."""
+    with pytest.raises(ValueError, match="Invalid region"):
+        prepare_query(BASE_SQL, BASE_META, params={"region": "us-east-1' OR '1'='1"})
+
+
+def test_region_with_uppercase_rejected():
+    """Regions must be lowercase per AWS convention."""
+    with pytest.raises(ValueError, match="Invalid region"):
+        prepare_query(BASE_SQL, BASE_META, params={"region": "US-EAST-1"})
+
+
+def test_region_too_long_rejected():
+    """Region strings longer than 30 chars should be rejected."""
+    with pytest.raises(ValueError, match="Invalid region"):
+        prepare_query(BASE_SQL, BASE_META, params={"region": "a" * 31})
+
+
+# ── generic param escaping ────────────────────────────────────────────────────
+
+def test_generic_param_quote_escaped():
+    """Single quotes in generic params must be escaped."""
+    sql = "SELECT * FROM resources WHERE {scan_filter} AND name = '{myval}'"
+    meta = {"name": "test", "description": "", "params": ["myval"]}
+    result = prepare_query(sql, meta, params={"myval": "test'injection"})
+    assert "test''injection" in result
+    assert "test'injection" not in result.replace("test''injection", "")

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,117 @@
+"""
+Tests for the --redact flag and redact_account_ids() in formatter.py.
+
+Verifies that account IDs are replaced with [REDACTED] in all output
+formats, and that filenames generated with --redact use REDACTED.
+"""
+
+import pytest
+
+from aws_inventory.formatter import redact_account_ids, format_output
+
+
+ACCOUNT_ID = "123456789012"
+
+SAMPLE_DATA = {
+    "metadata": {
+        "account_id": ACCOUNT_ID,
+        "timestamp": "2026-03-10T12:00:00",
+        "scan_duration_seconds": 1.0,
+        "resource_count": 1,
+        "services_scanned": 1,
+        "regions_scanned": 1,
+    },
+    "resources": [
+        {
+            "service": "s3",
+            "type": "bucket",
+            "id": "my-bucket",
+            "arn": f"arn:aws:s3:::my-bucket",
+            "name": "my-bucket",
+            "region": "us-east-1",
+            "account_id": ACCOUNT_ID,
+            "is_default": False,
+            "details": {},
+            "tags": {},
+        }
+    ],
+}
+
+
+# ── redact_account_ids() ──────────────────────────────────────────────────────
+
+def test_account_id_replaced_in_string():
+    content = f"Account: {ACCOUNT_ID} is the owner"
+    result = redact_account_ids(content, ACCOUNT_ID)
+    assert ACCOUNT_ID not in result
+    assert "[REDACTED]" in result
+
+
+def test_multiple_occurrences_replaced():
+    content = f"{ACCOUNT_ID} and again {ACCOUNT_ID}"
+    result = redact_account_ids(content, ACCOUNT_ID)
+    assert ACCOUNT_ID not in result
+    assert result.count("[REDACTED]") == 2
+
+
+def test_empty_account_id_noop():
+    content = "no account id here"
+    result = redact_account_ids(content, "")
+    assert result == content
+
+
+def test_none_like_empty_account_id_noop():
+    content = "no account id here"
+    result = redact_account_ids(content, "   ")
+    assert result == content
+
+
+def test_unrelated_content_unchanged():
+    content = "nothing sensitive"
+    result = redact_account_ids(content, ACCOUNT_ID)
+    assert result == content
+
+
+# ── format_output with redact=True ────────────────────────────────────────────
+
+def test_json_redact_removes_account_id():
+    output = format_output(SAMPLE_DATA, "json", redact=True)
+    assert ACCOUNT_ID not in output
+    assert "[REDACTED]" in output
+
+
+def test_csv_redact_removes_account_id():
+    output = format_output(SAMPLE_DATA, "csv", redact=True)
+    assert ACCOUNT_ID not in output
+
+
+def test_html_redact_removes_account_id():
+    output = format_output(SAMPLE_DATA, "html", redact=True)
+    assert ACCOUNT_ID not in output
+    assert "[REDACTED]" in output
+
+
+def test_json_no_redact_keeps_account_id():
+    output = format_output(SAMPLE_DATA, "json", redact=False)
+    assert ACCOUNT_ID in output
+
+
+def test_html_no_redact_keeps_account_id():
+    output = format_output(SAMPLE_DATA, "html", redact=False)
+    assert ACCOUNT_ID in output
+
+
+# ── format_output default (redact=False) ─────────────────────────────────────
+
+def test_redact_defaults_to_false():
+    """Calling format_output without redact= should NOT redact."""
+    output = format_output(SAMPLE_DATA, "json")
+    assert ACCOUNT_ID in output
+
+
+# ── completions file size limit ───────────────────────────────────────────────
+
+def test_completions_size_limit_constant():
+    """Verify the 1 MB size limit constant exists and is correctly set."""
+    from aws_inventory.completions import _AWS_CONFIG_MAX_BYTES
+    assert _AWS_CONFIG_MAX_BYTES == 1 * 1024 * 1024


### PR DESCRIPTION
## Summary

- **Input sanitization**: Escape SQL LIKE clause special characters (`'`, `\`, `%`, `_`) in NLQ engine; validate `service` against collector allowlist and `region` with regex in queries library
- **File permissions**: DB directory created `0o700`, DB file `chmod 0o600` after open; output files `chmod 0o600` after write
- **Path traversal protection**: `config.py` validates the `db` config key path stays within `$HOME`
- **Large file guard**: `completions.py` skips AWS config files >1 MB before parsing
- **`--redact` flag**: Replaces account ID with `[REDACTED]` in file content and auto-generated filenames

## Test plan

- [ ] Run `pytest tests/` — 50 tests, all passing across 5 new test modules:
  - `tests/test_nlq_injection.py` — NLQ LIKE injection cases
  - `tests/test_queries_lib_injection.py` — service/region allowlist validation
  - `tests/test_file_permissions.py` — DB and output file permission checks
  - `tests/test_config_security.py` — path traversal protection
  - `tests/test_redact.py` — `--redact` flag behavior
- [ ] Verify `awsmap --redact -f html` produces a redacted filename and file content
- [ ] Verify `awsmap config set db /tmp/outside_home.db` is rejected

## Remaining known issues (low severity, not in scope)

- **L1** `cli.py:173` — User ARN printed to stdout unconditionally
- **L2** All collectors — `except Exception: pass` silently swallows errors
- **L3** `db.py:61-66` — Brief race window between file creation and `chmod 0o600`
- **M1** Redshift/RDS collectors — `master_username` stored in inventory (metadata only, not passwords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>